### PR TITLE
Micropython compatible exception creation

### DIFF
--- a/apds9960/exceptions.py
+++ b/apds9960/exceptions.py
@@ -1,7 +1,7 @@
 class ADPS9960InvalidDevId(ValueError):
     def __init__(self, id, valid_ids):
-        Exception.__init__(self, "Device id 0x{} is not a valied one (valid: {})!".format(format(id, '02x'), ', '.join(["0x{}".format(format(i, '02x')) for i in valid_ids])))
+        super().__init__("Device id 0x{:02x} is not a valid one (valid: {})!".format(id, ', '.join(["0x{:02x}".format(i) for i in valid_ids])))
 
 class ADPS9960InvalidMode(ValueError):
     def __init__(self, mode):
-        Exception.__init__(self, "Feature mode {} is invalid!".format(mode))
+        super().__init__("Feature mode {} is invalid!".format(mode))


### PR DESCRIPTION
Use pythonic super(). Micropython has no standalone format function. Still works with CPython.

Fixes #10 and #15 